### PR TITLE
Release/2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 ## Table of contents
 
+- [2.1.2](#212)
 - [2.1.1](#211)
 - [2.1.0](#210)
 - [2.0.0](#200)
 - [1.0.1](#101)
 - [1.0.0](#100)
+
+## 2.1.2
+
+### Fixes
+
+- Fix `FieldConverter`s not being detected correctly in some cases in `create_template_from_model` (when their base class inherits `typing.Protocol`, for example)
 
 ## 2.1.1
 

--- a/phanas_pydantic_helpers/helpers/create_template_from_model.py
+++ b/phanas_pydantic_helpers/helpers/create_template_from_model.py
@@ -30,7 +30,10 @@ def create_template_from_type(type_: type[T], field_name: str) -> T:
     if isinstance(type_, ModelMetaclass):
         return create_template_from_model(type_)
 
-    if type(type_) is type and issubclass(type_, FieldConverter):
+    # If a class inherits a `typing.Protocol`, its type will not be `type`
+    # like expected, and `issubclass` will not be able to be run on it. We can
+    # search for FieldConverter in __mro__ instead.
+    if hasattr(type_, "__mro__") and FieldConverter in type_.__mro__:
         converters = (
             (getattr(type_, attr))
             for attr in vars(type_).keys()

--- a/phanas_pydantic_helpers/version.py
+++ b/phanas_pydantic_helpers/version.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "phanas-pydantic-helpers"
-version = "2.1.1"  # Also at version.py::__version__
+version = "2.1.2"  # Also at version.py::__version__
 description = "A collection of helper functions/classes for Pydantic."
 license = "MIT"
 authors = ["Phanabani <phanabani@gmail.com>"]

--- a/tests/test_create_template_from_model.py
+++ b/tests/test_create_template_from_model.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from pydantic import BaseModel
 import pytest
+from typing_extensions import Protocol
 
 from phanas_pydantic_helpers import (
     Factory,
@@ -240,3 +241,21 @@ class TestFieldConverter:
             to_container: ToContainer
 
         assert create_template_from_model(Model) == {"to_container": 0}
+
+    def test_mro(self):
+        class ContainerProto(Protocol):
+            value: int
+
+        class Container(ContainerProto):
+            def __init__(self, value: int):
+                self.value = value
+
+        class IntToContainerProtoImpl(Container, FieldConverter):
+            @classmethod
+            def _pyd_convert(cls, value: int):
+                return cls(value)
+
+        class Model(BaseModel):
+            int_to_container_proto_impl: IntToContainerProtoImpl
+
+        assert create_template_from_model(Model) == {"int_to_container_proto_impl": 0}


### PR DESCRIPTION
## 2.1.2

### Fixes

- Fix `FieldConverter`s not being detected correctly in some cases in `create_template_from_model` (when their base class inherits `typing.Protocol`, for example)
