### PR TITLE
Fix/name assumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,19 @@
 
 ## Table of contents
 
+- [2.1.3](#213)
 - [2.1.2](#212)
 - [2.1.1](#211)
 - [2.1.0](#210)
 - [2.0.0](#200)
 - [1.0.1](#101)
 - [1.0.0](#100)
+
+## 2.1.3
+
+### Fixes
+
+- Fix `FieldConverter` argument name being assumed in `create_template_from_model`
 
 ## 2.1.2
 

--- a/phanas_pydantic_helpers/helpers/create_template_from_model.py
+++ b/phanas_pydantic_helpers/helpers/create_template_from_model.py
@@ -41,9 +41,9 @@ def create_template_from_type(type_: type[T], field_name: str) -> T:
         )
         # We're going to get ONLY the first converter's value type
         try:
-            first_converter_type = get_function_args_annotations(next(converters))[
-                "value"
-            ]
+            first_converter_type = list(
+                get_function_args_annotations(next(converters)).values()
+            )[0]
         except StopIteration:
             raise ValueError(
                 f'FieldConverter named "{field_name}" has no converter methods'

--- a/phanas_pydantic_helpers/version.py
+++ b/phanas_pydantic_helpers/version.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "2.1.2"
+__version__ = "2.1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "phanas-pydantic-helpers"
-version = "2.1.2"  # Also at version.py::__version__
+version = "2.1.3"  # Also at version.py::__version__
 description = "A collection of helper functions/classes for Pydantic."
 license = "MIT"
 authors = ["Phanabani <phanabani@gmail.com>"]

--- a/tests/test_create_template_from_model.py
+++ b/tests/test_create_template_from_model.py
@@ -221,6 +221,21 @@ class TestFieldConverter:
 
         assert create_template_from_model(Model) == {"int_to_container": 0}
 
+    def test_allow_any_arg_name(self):
+        class Container:
+            def __init__(self, _testing_arg_name_: Any):
+                self._testing_arg_name_ = _testing_arg_name_
+
+        class IntToContainer(Container, FieldConverter):
+            @classmethod
+            def _pyd_convert(cls, _testing_arg_name_: int):
+                return cls(_testing_arg_name_)
+
+        class Model(BaseModel):
+            int_to_container: IntToContainer
+
+        assert create_template_from_model(Model) == {"int_to_container": 0}
+
     def test_gets_type_of_first_converter_only(self):
         class Container:
             def __init__(self, value: Any):


### PR DESCRIPTION
### Fixes

- Fix `FieldConverter` argument name being assumed in `create_template_from_model`